### PR TITLE
added decorators

### DIFF
--- a/server/src/app.controller.ts
+++ b/server/src/app.controller.ts
@@ -10,6 +10,12 @@ import { ReturnUserProfile } from './users/users.model';
 import { FriendInfoDTO } from './users/dtos/user-dtos';
 import { NotificationsService } from './notifications/notifications.service';
 import { ParseObjectIdPipe } from './core/pipe/object-id.pipe';
+import { 
+  IsAllowedToAddFriend,
+  IsUserAllowedToAddingChatGroup,
+  IsUserAllowedToRemovingFromChatGroup,
+  IsAllowedToRemoveFriend
+ } from './core/decorators/index';
 
 @Controller('app')
 export class AppController {
@@ -60,7 +66,7 @@ export class AppController {
       const userProfileInfo = await this.userService.mapUserProfileInfo({mapUserInfoDTO:{UserId, UserName, UserEmail, ChatGroupDetails, FriendsData}});
       return userProfileInfo;
   }
-  @UseGuards( JwtAuthGuard )
+  @UseGuards( JwtAuthGuard, IsUserAllowedToAddingChatGroup )
   @Post('/add-friends-to-chat-group/:chatGroupId/:friendId')
   async addFriendsToChatGroup(
     @Param('chatGroupId', ParseObjectIdPipe ) chatGroupId: string,
@@ -71,7 +77,7 @@ export class AppController {
       return updatedChatGroup ;
 
   }
-  @UseGuards( JwtAuthGuard )
+  @UseGuards( JwtAuthGuard, IsUserAllowedToRemovingFromChatGroup )
   @Post('/remove-friends-from-chat-group/:chatGroupId/:friendId')
   async removeFriendsFromChatGroup(
     @Param('chatGroupId', ParseObjectIdPipe ) chatGroupId: string, 
@@ -83,9 +89,9 @@ export class AppController {
       return updatedChatGroup;
 
   } 
-  @UseGuards( JwtAuthGuard )
+  @UseGuards( JwtAuthGuard, IsAllowedToAddFriend )
   @Post('/add-friend/:friendId')
-  async addFriend( 
+  async addFriend(
     @Param('friendId', ParseObjectIdPipe ) friendId: string, 
     @Request() req 
     ) : Promise<FriendInfoDTO> {
@@ -93,7 +99,7 @@ export class AppController {
       const updatedUser = await this.userService.addFriend( {userId: req.user.userId, friendId: friendId} );
       return updatedUser;
   }
-  @UseGuards( JwtAuthGuard )
+  @UseGuards( JwtAuthGuard, IsAllowedToRemoveFriend )
   @Post('/remove-friend/:friendId')
   async removeFriend( 
     @Param('friendId', ParseObjectIdPipe ) friendId: string, 

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -41,7 +41,7 @@ import { ScheduleModule } from '@nestjs/schedule';
     provide:APP_PIPE,
     useValue:new ValidationPipe({
       whitelist:true
-    })
+    }),
   }],
 })
 export class AppModule {

--- a/server/src/chat-groups/exceptions/index.ts
+++ b/server/src/chat-groups/exceptions/index.ts
@@ -76,6 +76,36 @@ export class CouldNotRemovedUserFromChatGroupException extends ChatAppException 
 
     }
 }
+export class UserAlreadyExistsInChatGroupException extends ChatAppException {
+    constructor( data?: string | object ){
+        super(
+            'Could not added user to chat group because user already exists in group.',
+            2032,
+            HttpStatus.BAD_REQUEST,
+            JSON.stringify(data),
+            'UserAlreadyExistsInChatGroupException'
+        );
+        
+        this.name ='UserAlreadyExistsInChatGroupException'
+        Object.setPrototypeOf(this, CouldNotRemovedUserFromChatGroupException.prototype);
+
+    }
+}
+export class UserNotExistsInChatGroupException extends ChatAppException {
+    constructor( data?: string | object ){
+        super(
+            'Could not removed user from chat group because user not exists in group.',
+            2033,
+            HttpStatus.BAD_REQUEST,
+            JSON.stringify(data),
+            'UserNotExistsInChatGroupException'
+        );
+        
+        this.name ='UserNotExistsInChatGroupException'
+        Object.setPrototypeOf(this, UserNotExistsInChatGroupException.prototype);
+
+    }
+}
 export class CouldNotUpdatedChatGroupNameException extends ChatAppException {
     constructor( data?: string | object ){
         super(

--- a/server/src/core/decorators/chatgroup-related-decorators/is-allowed-to-add-to-chatgroup.decorator.ts
+++ b/server/src/core/decorators/chatgroup-related-decorators/is-allowed-to-add-to-chatgroup.decorator.ts
@@ -1,0 +1,24 @@
+import { CanActivate, ExecutionContext, Injectable } from "@nestjs/common";
+import { ChatGroupsService } from "src/chat-groups/chat-groups.service";
+import { UserAlreadyExistsInChatGroupException } from "src/chat-groups/exceptions";
+
+@Injectable()
+export class IsUserAllowedToAddingChatGroup implements CanActivate {
+    constructor(
+        private readonly chatGroupService: ChatGroupsService
+    ){}
+
+    async canActivate(context: ExecutionContext): Promise<boolean> {
+        const { chatGroupService } = this;
+        const request = context.switchToHttp().getRequest();
+        const { chatGroupId, friendId } = request.params;
+
+        const chatGroupUsers = await chatGroupService.getChatGroupsUsers({chatGroupId});
+        const isUserAlreadyExistsInChatGroup = chatGroupUsers.includes(friendId);
+
+        if(isUserAlreadyExistsInChatGroup) {
+            throw new UserAlreadyExistsInChatGroupException(friendId);
+        }
+        return true;
+    }
+}

--- a/server/src/core/decorators/chatgroup-related-decorators/is-allowed-to-remove-from-chatgroup.decorator.ts
+++ b/server/src/core/decorators/chatgroup-related-decorators/is-allowed-to-remove-from-chatgroup.decorator.ts
@@ -1,0 +1,24 @@
+import { CanActivate, ExecutionContext, Injectable } from "@nestjs/common";
+import { ChatGroupsService } from "src/chat-groups/chat-groups.service";
+import { UserAlreadyExistsInChatGroupException, UserNotExistsInChatGroupException } from "src/chat-groups/exceptions";
+
+@Injectable()
+export class IsUserAllowedToRemovingFromChatGroup implements CanActivate {
+    constructor(
+        private readonly chatGroupService: ChatGroupsService
+    ){}
+
+    async canActivate(context: ExecutionContext): Promise<boolean> {
+        const { chatGroupService } = this;
+        const request = context.switchToHttp().getRequest();
+        const { chatGroupId, friendId } = request.params;
+
+        const chatGroupUsers = await chatGroupService.getChatGroupsUsers({chatGroupId});
+        const isUserNotExistsInChatGroup = chatGroupUsers.includes(friendId);
+
+        if(isUserNotExistsInChatGroup) {
+            return true;
+        }
+        throw new UserNotExistsInChatGroupException(friendId);
+    }
+}

--- a/server/src/core/decorators/index.ts
+++ b/server/src/core/decorators/index.ts
@@ -1,0 +1,4 @@
+export * from './user-related-decorators/is-allowed-to-add-friend';
+export * from './user-related-decorators/is-allowed-to-remove-friend.decorator';
+export * from './chatgroup-related-decorators/is-allowed-to-add-to-chatgroup.decorator';
+export * from './chatgroup-related-decorators/is-allowed-to-remove-from-chatgroup.decorator';

--- a/server/src/core/decorators/user-related-decorators/is-allowed-to-add-friend.ts
+++ b/server/src/core/decorators/user-related-decorators/is-allowed-to-add-friend.ts
@@ -1,0 +1,27 @@
+import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
+import { UsersService } from '../../../users/users.service';
+import { FriendAlreadyAddedException } from '../../../users/exceptions';
+
+@Injectable()
+export class IsAllowedToAddFriend implements CanActivate {
+  constructor(
+    private readonly usersService: UsersService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const { usersService } = this;
+    const request = context.switchToHttp().getRequest();
+    const { friendId } = request.params;
+    const { userId } = request.user;
+
+    const friendsIds = await usersService.getFriendIdsOfUser({ userId });
+
+    const isFriend = friendsIds.includes(friendId);
+
+    if (isFriend) {
+      throw new FriendAlreadyAddedException(friendId);
+    }
+
+    return true;
+  }
+}

--- a/server/src/core/decorators/user-related-decorators/is-allowed-to-remove-friend.decorator.ts
+++ b/server/src/core/decorators/user-related-decorators/is-allowed-to-remove-friend.decorator.ts
@@ -1,0 +1,25 @@
+import { CanActivate, ExecutionContext, Injectable } from "@nestjs/common";
+import { FriendCouldNotRemovedException } from "src/users/exceptions";
+import { UsersService } from "src/users/users.service";
+
+@Injectable()
+export class IsAllowedToRemoveFriend implements CanActivate {
+    constructor(
+        private readonly usersService: UsersService
+        ){}
+    async canActivate(context: ExecutionContext): Promise<boolean>  {
+        const { usersService } = this;
+        const request = context.switchToHttp().getRequest();
+        const { friendId } = request.params;
+        const { userId } = request.user;
+
+        const friendIds = await usersService.getFriendIdsOfUser({userId});
+        
+        const isFriend = friendIds.includes(friendId);
+
+        if(isFriend){
+            return true;
+        }
+        throw new FriendCouldNotRemovedException(friendId);
+    }
+}

--- a/server/src/users/exceptions/index.ts
+++ b/server/src/users/exceptions/index.ts
@@ -188,3 +188,17 @@ export class FriendCouldNotRemovedException extends ChatAppException {
         Object.setPrototypeOf(this, FriendCouldNotRemovedException.prototype);
     }
 }
+export class FriendAlreadyAddedException extends ChatAppException {
+    constructor( data?: string | object ) {
+        super(
+            'Friend could not added because it already exists',
+            1072,
+            HttpStatus.BAD_REQUEST,
+            JSON.stringify(data),
+            'FriendAlreadyAddedException'
+        );
+
+        this.name = 'FriendAlreadyAddedException';
+        Object.setPrototypeOf(this, FriendAlreadyAddedException.prototype);
+    }
+}

--- a/server/src/users/users.service.ts
+++ b/server/src/users/users.service.ts
@@ -8,7 +8,6 @@ import {
     ReturnUser, 
     ReturnUserProfile, 
     ReturnUserToBeAuth, 
-    User, 
     UserToBeValidate } from './users.model';
 import { 
     UserToBeValidateDTO, 


### PR DESCRIPTION
Added Decorators for checking:
- Handling the request satisfaction of the functions that are related with the logic.
- Added user related decorators from now on when a user tries to add or remove a user from users Friends array  isallowedtoadd or isallowedtoremove decorators are checks:
  - When user is sended a request about adding friend and if friendId is already  exists in users Friends array then decorator throws a custom exception
  -  When user is sended a request about removing friend and if friendId is already not exists in users Friends array then decorator throws a custom exception.
- Added chatgroups related decorators from now on when a user tries to add or remove a user from users ChatGroups Users array  isallowedtoaddtochatgorup or isallowedtoremovefromchatgroup decorators are checks:
  - When user is sended a request about adding friend to chat group and if friendId is already exists in chatgroups Users array then decorator throws a custom exception.
  - When user is sended a request about removing friend from chat group and if friendId is already not exists in chatgroups Users array then decorator throws a custom exception.